### PR TITLE
BBIQ push command & JSON testdata

### DIFF
--- a/importer/README.md
+++ b/importer/README.md
@@ -87,6 +87,7 @@ cat local/minimal_test_database.sql | docker exec -i postgres psql -U bookbrainz
 cat sql/migrations/series/up.sql | docker exec -i postgres psql -U bookbrainz -d bookbrainz_min
 cat sql/migrations/series-identifiers/up.sql | docker exec -i postgres psql -U bookbrainz -d bookbrainz_min
 cat sql/migrations/series-achievement/up.sql | docker exec -i postgres psql -U bookbrainz -d bookbrainz_min
+cat sql/scripts/create_triggers.sql | docker exec -i postgres psql -U bookbrainz -d bookbrainz_min
 
 cat local/minimal_test_database_import_patch.sql | docker exec -i postgres psql -U bookbrainz -d bookbrainz_min
 

--- a/importer/README.md
+++ b/importer/README.md
@@ -96,6 +96,7 @@ cat sql/migrations/user-collection/up.sql | docker exec -i postgres psql -U book
 cat sql/migrations/2023-05-29-user_privileges/up.sql | docker exec -i postgres psql -U bookbrainz -d bookbrainz_min
 cat sql/migrations/2023-05-29-admin_logs/up.sql | docker exec -i postgres psql -U bookbrainz -d bookbrainz_min
 cat sql/migrations/relationship-attributes/up.sql | docker exec -i postgres psql -U bookbrainz -d bookbrainz_min
+cat sql/migrations/2021-author-credits/up.sql | docker exec -i postgres psql -U bookbrainz -d bookbrainz_min
 # CritiqueBrainz OAuth
 cat sql/migrations/2022-07-19/up.sql | docker exec -i postgres psql -U bookbrainz -d bookbrainz_min
 ```

--- a/importer/src/consumer/validators/index.ts
+++ b/importer/src/consumer/validators/index.ts
@@ -141,7 +141,7 @@ function validateEntity(validationFunction, entityType: EntityTypeString) {
 					pages: editionData.pages,
 					// TODO: publisher: idToEntityStub(editionData.publisher),
 					// TODO: release events (date and country) should not be mapped to just a date
-					// releaseDate: editionData.releaseDate,
+					releaseDate: editionData.releaseEvents?.[0]?.date,
 					status: editionData.statusId,
 					weight: editionData.weight,
 					width: editionData.width

--- a/importer/src/consumer/validators/index.ts
+++ b/importer/src/consumer/validators/index.ts
@@ -137,7 +137,7 @@ function validateEntity(validationFunction, entityType: EntityTypeString) {
 					editionGroup: idToEntityStub(editionData.editionGroupBbid),
 					format: editionData.formatId,
 					height: editionData.height,
-					languages: editionData.languages.map(({id}) => ({value: id})),
+					languages: editionData.languages?.map(({id}) => ({value: id})),
 					pages: editionData.pages,
 					// TODO: publisher: idToEntityStub(editionData.publisher),
 					// TODO: release events (date and country) should not be mapped to just a date

--- a/importer/src/consumer/validators/index.ts
+++ b/importer/src/consumer/validators/index.ts
@@ -28,16 +28,16 @@ import {type AuthorSection, validateAuthor} from 'bookbrainz-data/lib/validators
 import {type EditionGroupSection, validateEditionGroup} from 'bookbrainz-data/lib/validators/edition-group.js';
 import {type EditionSection, validateEdition} from 'bookbrainz-data/lib/validators/edition.js';
 import type {
-	ParsedAuthor, ParsedEdition, ParsedEditionGroup, ParsedEntity, ParsedPublisher, ParsedWork
+	ParsedAuthor, ParsedEdition, ParsedEditionGroup, ParsedEntity, ParsedPublisher, ParsedSeries, ParsedWork
 } from 'bookbrainz-data/lib/types/parser.d.ts';
 import {type PublisherSection, validatePublisher} from 'bookbrainz-data/lib/validators/publisher.js';
+import {type SeriesSection, validateSeries} from 'bookbrainz-data/lib/validators/series.js';
 import {type WorkSection, validateWork} from 'bookbrainz-data/lib/validators/work.js';
 import type {AliasWithDefaultT} from 'bookbrainz-data/lib/types/aliases.d.ts';
 import type {EntityTypeString} from 'bookbrainz-data/lib/types/entity.d.ts';
 import {ValidationError} from 'bookbrainz-data/lib/validators/base.js';
 import _ from 'lodash';
 import log from '../../helpers/logger.ts';
-import {validateSeries} from 'bookbrainz-data/lib/validators/series.js';
 
 
 function getAliasSection(record: ParsedEntity): AliasSection {
@@ -165,6 +165,12 @@ function validateEntity(validationFunction, entityType: EntityTypeString) {
 					type: publisherData.typeId
 				};
 				break;
+			case 'Series':
+				const seriesData = validationData as ParsedSeries;
+				validationObject.seriesSection = {
+					orderType: seriesData.orderingTypeId,
+					seriesType: seriesData.entityType
+				};
 			case 'Work':
 				const workData = validationData as ParsedWork;
 				validationObject.workSection = {
@@ -216,5 +222,6 @@ type EntityValidationSections = CommonValidationSections & Partial<{
 	editionSection: EditionSection;
 	editionGroupSection: EditionGroupSection;
 	publisherSection: PublisherSection;
+	seriesSection: SeriesSection;
 	workSection: WorkSection;
 }>;

--- a/importer/src/consumer/validators/index.ts
+++ b/importer/src/consumer/validators/index.ts
@@ -18,10 +18,15 @@
  */
 
 
-import type {AliasSection, IdentifierSection, NameSection} from 'bookbrainz-data/lib/validators/common.d.ts';
+import type {
+	AliasSection,
+	AnnotationSection,
+	IdentifierSection,
+	NameSection
+} from 'bookbrainz-data/lib/validators/common.d.ts';
 import {type AuthorSection, validateAuthor} from 'bookbrainz-data/lib/validators/author.js';
-import {type EditionSection, validateEdition} from 'bookbrainz-data/lib/validators/edition.js';
 import {type EditionGroupSection, validateEditionGroup} from 'bookbrainz-data/lib/validators/edition-group.js';
+import {type EditionSection, validateEdition} from 'bookbrainz-data/lib/validators/edition.js';
 import type {
 	ParsedAuthor, ParsedEdition, ParsedEditionGroup, ParsedEntity, ParsedPublisher, ParsedWork
 } from 'bookbrainz-data/lib/types/parser.d.ts';
@@ -50,6 +55,12 @@ function getAliasSection(record: ParsedEntity): AliasSection {
 	}
 
 	return aliasSection;
+}
+
+function getAnnotationSection(record: ParsedEntity): AnnotationSection {
+	return {
+		content: record.annotation
+	};
 }
 
 function getDefaultAlias(aliasList: AliasWithDefaultT[]): AliasWithDefaultT {
@@ -95,6 +106,7 @@ function validateEntity(validationFunction, entityType: EntityTypeString) {
 		// Construct generic validation object from data set for validation
 		const validationObject: EntityValidationSections = {
 			aliasEditor: getAliasSection(validationData),
+			annotationSection: getAnnotationSection(validationData),
 			identifierEditor: getIdentifierSection(validationData),
 			nameSection: getNameSection(validationData)
 		};
@@ -194,6 +206,7 @@ export default validate;
 
 type CommonValidationSections = {
 	aliasEditor: AliasSection;
+	annotationSection: AnnotationSection;
 	identifierEditor: IdentifierSection;
 	nameSection: NameSection;
 };

--- a/importer/testdata/author.json
+++ b/importer/testdata/author.json
@@ -6,15 +6,33 @@
 			"languageId": 120,
 			"default": true,
 			"primary": true
+		}, {
+			"name": "MusicBrainz Test Artist",
+			"sortName": "Author, Test",
+			"languageId": 120,
+			"primary": false
+		}, {
+			"name": "Auteur du Test",
+			"sortName": "Test, Auteur du",
+			"languageId": 134,
+			"primary": true
 		}],
 		"disambiguation": "import test",
 		"type": "Person",
 		"typeId": 1,
 		"genderId": 3,
+		"beginAreaId": 8558,
 		"beginDate": "1701-04-23",
+		"endAreaId": 98703,
 		"endDate": "1742-12-31",
 		"ended": true,
-		"identifiers": [],
+		"identifiers": [{
+			"typeId": 2,
+			"value": "7e84f845-ac16-41fe-9ff8-df12eb32af55"
+		}, {
+			"typeId": 23,
+			"value": "OL3673719A"
+		}],
 		"annotation": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Iusto enim reprehenderit dolorum iure eaque accusamus, soluta pariatur aliquam commodi repellat cumque quaerat possimus nesciunt molestiae. Sunt deserunt magnam sint repellendus.",
 		"metadata": {
 			"links": [{
@@ -26,7 +44,7 @@
 		"source": "Testdata"
 	},
 	"entityType": "Author",
-	"lastEdited": "2024-07-17",
-	"originId": "A123",
+	"lastEdited": "2024-07-25",
+	"originId": "A1234",
 	"source": "Testdata"
 }

--- a/importer/testdata/author.json
+++ b/importer/testdata/author.json
@@ -1,0 +1,32 @@
+{
+	"data": {
+		"alias": [{
+			"name": "Test Author",
+			"sortName": "Author, Test",
+			"languageId": 120,
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"type": "Person",
+		"typeId": 1,
+		"genderId": 3,
+		"beginDate": "1701-04-23",
+		"endDate": "1742-12-31",
+		"ended": true,
+		"identifiers": [],
+		"annotation": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Iusto enim reprehenderit dolorum iure eaque accusamus, soluta pariatur aliquam commodi repellat cumque quaerat possimus nesciunt molestiae. Sunt deserunt magnam sint repellendus.",
+		"metadata": {
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/author"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "Author",
+	"lastEdited": "2024-07-17",
+	"originId": "A123",
+	"source": "Testdata"
+}

--- a/importer/testdata/author.ts
+++ b/importer/testdata/author.ts
@@ -8,15 +8,33 @@ export const entity: QueuedEntity<ParsedAuthor> = {
 			"languageId": 120, // English, TODO: use language codes
 			"default": true,
 			"primary": true
+		}, {
+			"name": "MusicBrainz Test Artist",
+			"sortName": "Author, Test",
+			"languageId": 120, // English
+			"primary": false
+		}, {
+			"name": "Auteur du Test",
+			"sortName": "Test, Auteur du",
+			"languageId": 134, // French
+			"primary": true
 		}],
 		"disambiguation": "import test",
 		"type": "Person", // unused, TODO: map to ID
 		"typeId": 1, // Person
 		"genderId": 3, // Other
+		"beginAreaId": 8558, // Hill
 		"beginDate": "1701-04-23",
+		"endAreaId": 98703, // Ciudad Nezahualcóyotl
 		"endDate": "1742-12-31",
 		"ended": true,
-		"identifiers": [],
+		"identifiers": [{
+			"typeId": 2, // MusicBrainz Artist ID
+			"value": "7e84f845-ac16-41fe-9ff8-df12eb32af55"
+		}, {
+			"typeId": 23, // OpenLibrary Author ID
+			"value": "OL3673719A"
+		}],
 		"annotation": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Iusto enim reprehenderit dolorum iure eaque accusamus, soluta pariatur aliquam commodi repellat cumque quaerat possimus nesciunt molestiae. Sunt deserunt magnam sint repellendus.",
 		"metadata": { // currently unused
 			"links": [{
@@ -28,7 +46,7 @@ export const entity: QueuedEntity<ParsedAuthor> = {
 		"source": "Testdata"
 	},
 	"entityType": "Author",
-	"lastEdited": "2024-07-17",
-	"originId": "A123", // change this to import another dummy entity
+	"lastEdited": "2024-07-25",
+	"originId": "A1234", // change this to import another dummy entity
 	"source": "Testdata"
 };

--- a/importer/testdata/author.ts
+++ b/importer/testdata/author.ts
@@ -1,0 +1,34 @@
+import type {ParsedAuthor, QueuedEntity} from 'bookbrainz-data/lib/types/parser.d.ts';
+
+export const entity: QueuedEntity<ParsedAuthor> = {
+	"data": {
+		"alias": [{
+			"name": "Test Author",
+			"sortName": "Author, Test",
+			"languageId": 120, // English, TODO: use language codes
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"type": "Person", // unused, TODO: map to ID
+		"typeId": 1, // Person
+		"genderId": 3, // Other
+		"beginDate": "1701-04-23",
+		"endDate": "1742-12-31",
+		"ended": true,
+		"identifiers": [],
+		"annotation": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Iusto enim reprehenderit dolorum iure eaque accusamus, soluta pariatur aliquam commodi repellat cumque quaerat possimus nesciunt molestiae. Sunt deserunt magnam sint repellendus.",
+		"metadata": { // currently unused
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/author"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "Author",
+	"lastEdited": "2024-07-17",
+	"originId": "A123", // change this to import another dummy entity
+	"source": "Testdata"
+};

--- a/importer/testdata/edition.json
+++ b/importer/testdata/edition.json
@@ -1,0 +1,36 @@
+{
+	"data": {
+		"alias": [{
+			"name": "The Complete Test Collection",
+			"sortName": "Complete Test Collection, The",
+			"languageId": 120,
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"editionGroupBbid": "PLEASE-FILL-WITH-VALID-BBID",
+		"formatId": 2,
+		"statusId": 1,
+		"releaseEvents": [{"date": "2024-04-23"}],
+		"languages": [{"id": 134}, {"id": 145}],
+		"pages": 987,
+		"weight": 450,
+		"width": 150,
+		"height": 270,
+		"depth": 75,
+		"identifiers": [],
+		"annotation": "Unabridged edition with illustrations.",
+		"metadata": {
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/edition"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "Edition",
+	"lastEdited": "2024-07-24",
+	"originId": "E123",
+	"source": "Testdata"
+}

--- a/importer/testdata/edition.ts
+++ b/importer/testdata/edition.ts
@@ -1,0 +1,38 @@
+import type {ParsedEdition, QueuedEntity} from 'bookbrainz-data/lib/types/parser.d.ts';
+
+export const entity: QueuedEntity<ParsedEdition> = {
+	"data": {
+		"alias": [{
+			"name": "The Complete Test Collection",
+			"sortName": "Complete Test Collection, The",
+			"languageId": 120, // English, TODO: use language codes
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"editionGroupBbid": "PLEASE-FILL-WITH-VALID-BBID", // has to exist
+		"formatId": 2, // Hardcover
+		"statusId": 1, // Official
+		"releaseEvents": [{"date": "2024-04-23"}],
+		"languages": [{"id": 134}, {"id": 145}], // French, German
+		"pages": 987,
+		"weight": 450,
+		"width": 150,
+		"height": 270,
+		"depth": 75,
+		"identifiers": [],
+		"annotation": "Unabridged edition with illustrations.",
+		"metadata": { // currently unused
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/edition"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "Edition",
+	"lastEdited": "2024-07-24",
+	"originId": "E123", // change this to import another dummy entity
+	"source": "Testdata"
+};

--- a/importer/testdata/edition_group.json
+++ b/importer/testdata/edition_group.json
@@ -1,0 +1,27 @@
+{
+	"data": {
+		"alias": [{
+			"name": "The Complete Test Collection",
+			"sortName": "Complete Test Collection, The",
+			"languageId": 120,
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"typeId": 1,
+		"identifiers": [],
+		"annotation": "Empty edition group",
+		"metadata": {
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/edition-group"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "EditionGroup",
+	"lastEdited": "2024-07-22",
+	"originId": "G123",
+	"source": "Testdata"
+}

--- a/importer/testdata/edition_group.ts
+++ b/importer/testdata/edition_group.ts
@@ -1,0 +1,29 @@
+import type {ParsedEditionGroup, QueuedEntity} from 'bookbrainz-data/lib/types/parser.d.ts';
+
+export const entity: QueuedEntity<ParsedEditionGroup> = {
+	"data": {
+		"alias": [{
+			"name": "The Complete Test Collection",
+			"sortName": "Complete Test Collection, The",
+			"languageId": 120, // English, TODO: use language codes
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"typeId": 1, // Book
+		"identifiers": [],
+		"annotation": "Empty edition group",
+		"metadata": { // currently unused
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/edition-group"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "EditionGroup",
+	"lastEdited": "2024-07-22",
+	"originId": "G123", // change this to import another dummy entity
+	"source": "Testdata"
+};

--- a/importer/testdata/publisher.json
+++ b/importer/testdata/publisher.json
@@ -1,0 +1,30 @@
+{
+	"data": {
+		"alias": [{
+			"name": "BookBrainz Press",
+			"sortName": "BookBrainz Press",
+			"languageId": 120,
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"typeId": 1,
+		"areaId": 8,
+		"beginDate": "2014",
+		"ended": false,
+		"identifiers": [],
+		"annotation": "Imagine a book which is only published in its BookBrainz annotation",
+		"metadata": {
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/publisher"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "Publisher",
+	"lastEdited": "2024-07-24",
+	"originId": "P123",
+	"source": "Testdata"
+}

--- a/importer/testdata/publisher.ts
+++ b/importer/testdata/publisher.ts
@@ -1,0 +1,32 @@
+import type {ParsedPublisher, QueuedEntity} from 'bookbrainz-data/lib/types/parser.d.ts';
+
+export const entity: QueuedEntity<ParsedPublisher> = {
+	"data": {
+		"alias": [{
+			"name": "BookBrainz Press",
+			"sortName": "BookBrainz Press",
+			"languageId": 120, // English, TODO: use language codes
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"typeId": 1, // Publisher
+		"areaId": 8, // Antarctica (worldwide is not in the minimal DB)
+		"beginDate": "2014",
+		"ended": false,
+		"identifiers": [],
+		"annotation": "Imagine a book which is only published in its BookBrainz annotation",
+		"metadata": { // currently unused
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/publisher"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "Publisher",
+	"lastEdited": "2024-07-24",
+	"originId": "P123", // change this to import another dummy entity
+	"source": "Testdata"
+};

--- a/importer/testdata/series.json
+++ b/importer/testdata/series.json
@@ -1,0 +1,28 @@
+{
+	"data": {
+		"alias": [{
+			"name": "All Adventures of Jane Doe",
+			"sortName": "All Adventures of Jane Doe",
+			"languageId": 120,
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"entityType": "Work",
+		"orderingTypeId": 1,
+		"identifiers": [],
+		"annotation": "Empty series",
+		"metadata": {
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/series"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "Series",
+	"lastEdited": "2024-07-24",
+	"originId": "S123",
+	"source": "Testdata"
+}

--- a/importer/testdata/series.ts
+++ b/importer/testdata/series.ts
@@ -1,0 +1,30 @@
+import type {ParsedSeries, QueuedEntity} from 'bookbrainz-data/lib/types/parser.d.ts';
+
+export const entity: QueuedEntity<ParsedSeries> = {
+	"data": {
+		"alias": [{
+			"name": "All Adventures of Jane Doe",
+			"sortName": "All Adventures of Jane Doe",
+			"languageId": 120, // English, TODO: use language codes
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"entityType": "Work",
+		"orderingTypeId": 1, // Automatic
+		"identifiers": [],
+		"annotation": "Empty series",
+		"metadata": { // currently unused
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/series"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "Series",
+	"lastEdited": "2024-07-24",
+	"originId": "S123", // change this to import another dummy entity
+	"source": "Testdata"
+};

--- a/importer/testdata/work.json
+++ b/importer/testdata/work.json
@@ -1,0 +1,27 @@
+{
+	"data": {
+		"alias": [{
+			"name": "The Fairytale Test",
+			"sortName": "Fairytale Test, The",
+			"languageId": 120,
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"typeId": 2,
+		"identifiers": [],
+		"annotation": "Once upon a time...",
+		"metadata": {
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/work"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "Work",
+	"lastEdited": "2024-07-17",
+	"originId": "W123",
+	"source": "Testdata"
+}

--- a/importer/testdata/work.ts
+++ b/importer/testdata/work.ts
@@ -1,0 +1,29 @@
+import type {ParsedWork, QueuedEntity} from 'bookbrainz-data/lib/types/parser.d.ts';
+
+export const entity: QueuedEntity<ParsedWork> = {
+	"data": {
+		"alias": [{
+			"name": "The Fairytale Test",
+			"sortName": "Fairytale Test, The",
+			"languageId": 120, // English, TODO: use language codes
+			"default": true,
+			"primary": true
+		}],
+		"disambiguation": "import test",
+		"typeId": 2, // Short Story
+		"identifiers": [],
+		"annotation": "Once upon a time...",
+		"metadata": { // currently unused
+			"links": [{
+				"title": "Example link",
+				"url": "https://example.com/work"
+			}],
+			"relationships": []
+		},
+		"source": "Testdata"
+	},
+	"entityType": "Work",
+	"lastEdited": "2024-07-17",
+	"originId": "W123", // change this to import another dummy entity
+	"source": "Testdata"
+};


### PR DESCRIPTION
The BBIQ CLI got a new command which allows you to directly push the contents of a JSON file into the queue, which is useful for testing and debugging.
Especially with the upcoming entity import schema change I wanted to make the current BB importer setup more battle-proofed before I am going break everything again.

So I've produced a few files with test data which cover all currently available properties of the following entity types:
- [x] Author
- [x] Edition (requires an edition group BBID)
- [x] Edition Group
- [x] Publisher
- [x] Series
- [x] Work

I am going to mark this PR as a draft until I have tested the remaining entity types as much as possible (but without doing changes which would have to be redone after the schema change).

The main issue which I discovered with these tools was the lack of support for annotations on imported entities. See the following PRs for all issues:
- https://github.com/metabrainz/bookbrainz-site/pull/1107
- https://github.com/metabrainz/bookbrainz-data-js/pull/320
- https://github.com/metabrainz/bookbrainz-data-js/pull/321
- https://github.com/metabrainz/bookbrainz-site/pull/1109